### PR TITLE
index: Added April-May 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,16 @@
         <label for="branch">Branch</label>
         <select name="branch" id="branch">
           <option value="CS" selected>CSE</option>
+          <option value="AD">AD</option>
+          <option value="AM">AM</option>
+          <option value="BM">BM</option>
+          <option value="BT">BT</option>
+          <option value="CA">CA</option>
+          <option value="CE">CE</option>
+          <option value="CC">CC</option>
           <option value="EC">ECE</option>
           <option value="EE">EEE</option>
+          <option value="ER">ER</option>
           <option value="ME">ME</option>
           <option value="CE">CE</option>
           <option value="IT">IT</option>

--- a/main.js
+++ b/main.js
@@ -30,122 +30,351 @@ const examsDetails = {
 
     },
     "S4": {
+        "AD": [
+            {"code": "MAT256", "date": "April 28, 2025 9:30:00", "name": "PROBABILITY AND STATISTICAL MODELING", "id": 1 },
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "CST204", "date": "May 8, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "CST206", "date": "May 23, 2025 9:30:00", "name": "OPERATING SYSTEMS", "id":7},
+        ],
+
+        "AM": [
+            {"code": "MAT216", "date": "April 28, 2025 9:30:00", "name": " MATHEMATICAL FOUNDATIONS FOR MACHINE LEARNING", "id": 1 },
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "CST204", "date": "May 8, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "CST206", "date": "May 23, 2025 9:30:00", "name": "OPERATING SYSTEMS", "id":7},
+        ],
+
+        "BM": [
+            {"code": "BMT202", "date": "May 2, 2025 9:30:00", "name": "MICROCONTROLLERS AND INTERFACING", "id":1},
+            {"code": "BMT204", "date": "May 8, 2025 9:30:00", "name": "ELECTRICAL AND ELECTRONIC INSTRUMENTATION", "id":2},
+            {"code": "BMT206", "date": "May 13, 2025 9:30:00", "name": "BIOPHYSICS", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+        ],
+
+        "BT": [
+            {"code": "BTT202", "date": "May 2, 2025 9:30:00", "name": "CHEMICAL AND BIOLOGICAL REACTION ENGINEERING", "id":1},
+            {"code": "BTT204", "date": "May 8, 2025 9:30:00", "name": "PRINCIPLES OF BIOCHEMISTRY", "id":2},
+            {"code": "BTT206", "date": "May 13, 2025 9:30:00", "name": "BIOPROCESS ENGINEERING", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+        ],
+
+        "CA": [
+            {"code": "MAT236", "date": "April 28, 2025 9:30:00", "name": "MATHEMATICS FOR ARTIFICIAL INTELLIGENCE", "id": 1 },
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "CST204", "date": "May 8, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "CST206", "date": "May 23, 2025 9:30:00", "name": "OPERATING SYSTEMS", "id":7},
+        ],
+
+        "CE": [
+            {"code": "CET202", "date": "May 2, 2025 9:30:00", "name": "ENGINEERING GEOLOGY", "id": 1 },
+            {"code": "CET204", "date": "May 8, 2025 9:30:00", "name": "GEOTECHNICAL ENGINEERING I", "id":2},
+            {"code": "CET206", "date": "May 13, 2025 9:30:00", "name": "TRANSPORTATION ENGINEERING", "id":3},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+        ],
+
+        "CC": [
+            {"code": "MAT266", "date": "April 28, 2025 9:30:00", "name": "MATHEMATICAL FOUNDATIONS FOR SECURITY SYSTEMS", "id": 1 },
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "CST204", "date": "May 8, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "CST206", "date": "May 23, 2025 9:30:00", "name": "OPERATING SYSTEMS", "id":7},
+        ],
+
         "CS": [
-            {"code": "MAT206", "date": "May 24, 2024 9:30:00", "name": "GRAPH THEORY", "id": 1 },
-            {"code": "CST202", "date": "May 29, 2024 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
-            {"code": "CST204", "date": "June 4, 2024 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
-            {"code": "HUT200", "date": "June 12, 2024 9:30:00", "name": "PROFESSIONAL ETHICS", "id":4},
-            {"code": "MCN202", "date": "June 15, 2024 9:30:00", "name": "CONSTITUTION OF INDIA", "id":5},
-            {"code": "CST206", "date": "June 19, 2024 9:30:00", "name": "OPERATING SYSTEMS", "id":6},
+            {"code": "MAT206", "date": "April 28, 2025 9:30:00", "name": "GRAPH THEORY", "id": 1 },
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "CST204", "date": "May 8, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "CST206", "date": "May 23, 2025 9:30:00", "name": "OPERATING SYSTEMS", "id":7},
         ],
 
         "EC": [
-            {"code": "MAT204", "date": "May 24, 2024 9:30:00", "name": "PROBABILITY, RANDOM PROCESS AND NUMERICAL METHODS", "id": 1 },
-            {"code": "ECT202", "date": "May 29, 2024 9:30:00", "name": "ANALOG CIRCUITS", "id":2},
-            {"code": "ECT204", "date": "June 4, 2024 9:30:00", "name": "SIGNALS AND SYSTEMS", "id":3},
-            {"code": "MET206", "date": "June 7, 2024 9:30:00", "name": "MANUFACTURING PROCESS", "id":4},
-            {"code": "HUT200", "date": "June 12, 2024 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
-            {"code": "MCN202", "date": "June 15, 2024 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "ECT202", "date": "May 2, 2025 9:30:00", "name": "ANALOG CIRCUITS", "id":1},
+            {"code": "ECT204", "date": "May 8, 2025 9:30:00", "name": "SIGNALS AND SYSTEMS", "id":2},
+            {"code": "ECT206", "date": "May 13, 2025 9:30:00", "name": "COMPUTER ARCHITECTURE AND MICROCONTROLLERS*", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+
+        ],
+
+        "ER": [
+            {"code": "MAT204", "date": "April 28, 2025 9:30:00", "name": "PROBABILITY, RANDOM PROCESS AND NUMERICAL METHODS", "id":1},
+            {"code": "CST202", "date": "May 2, 2025 9:30:00", "name": "COMPUTER ORGANISATION AND ARCHITECTURE", "id":2},
+            {"code": "ERT204", "date": "May 13, 2025 9:30:00", "name": "OBJECT ORIENTED PROGRAMMING USING JAVA", "id":3},
+            {"code": "ERT206", "date": "May 13, 2025 9:30:00", "name": "INTEGRATED CIRCUITS", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":6},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":7},
+
+        ],
+
+        "IT": [
+            {"code": "ITT202", "date": "May 2, 2025 9:30:00", "name": "PRINCIPLES OF OBJECT ORIENTED TECHNIQUES", "id": 1 },
+            {"code": "ITT204", "date": "May 8, 2025 9:30:00", "name": "COMPUTER ORGANIZATION", "id":2},
+            {"code": "ITT206", "date": "May 13, 2025 9:30:00", "name": "DATABASE MANAGEMENT SYSTEMS", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":6},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":7},
 
         ],
 
         "ME": [
-            {"code": "MAT202", "date": "May 24, 2024 9:30:00", "name": "PROBABILITY, STATISTICS AND NUMERICAL METHODS", "id": 1 },
-            {"code": "MET202", "date": "May 29, 2024 9:30:00", "name": "ENGINEERING THERMODYNAMICS", "id":2},
-            {"code": "MET204", "date": "June 4, 2024 9:30:00", "name": "MANUFACTURING PROCESS", "id":3},
-            {"code": "MET206", "date": "June 7, 2024 9:30:00", "name": "FLUID MACHINERY", "id":4},
-            {"code": "HUT200", "date": "June 12, 2024 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
-            {"code": "MCN202", "date": "June 15, 2024 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
+            {"code": "MAT202", "date": "April 28, 2025 9:30:00", "name": "PROBABILITY, STATISTICS AND NUMERICAL METHODS", "id": 1 },
+            {"code": "MET202", "date": "May 2, 2025 9:30:00", "name": "ENGINEERING THERMODYNAMICS", "id":2},
+            {"code": "MET204", "date": "May 8, 2025 9:30:00", "name": "MANUFACTURING PROCESS", "id":3},
+            {"code": "MET206", "date": "May 13, 2025 9:30:00", "name": "FLUID MACHINERY", "id":4},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":5},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":6},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":7},
+        ],
+
+        "EE": [
+            {"code": "EET202", "date": "May 2, 2025 9:30:00", "name": "DC MACHINES AND TRANSFORMERS", "id": 1 },
+            {"code": "EET204", "date": "May 8, 2025 9:30:00", "name": "ELECTROMAGNETIC THEORY", "id":2},
+            {"code": "EET206", "date": "May 13, 2025 9:30:00", "name": "DIGITAL ELECTRONICS", "id":3},
+            {"code": "EST200", "date": "May 16, 2025 9:30:00", "name": "DESIGN AND ENGINEERING", "id":4},
+            {"code": "HUT200", "date": "May 16, 2025 9:30:00", "name": "PROFESSIONAL ETHICS", "id":5},
+            {"code": "MCN202", "date": "May 20, 2025 9:30:00", "name": "CONSTITUTION OF INDIA", "id":6},
         ],
 
     },
     "S6": {
-        "CS": [
-            { "code": "CST302", "date": "May 23, 2024 9:30:00", "name": "Compiler Design", "id": 1 },
-            { "code": "CST304", "date": "May 28, 2024 9:30:00", "name": "Computer Graphics And Image Processing", "id": 2 },
-            { "code": "CST306", "date": "June 1, 2024 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
-            { "code": "CST3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "CST308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+        "AD": [
+            { "code": "ADT302", "date": "April 25, 2025 9:30:00", "name": "Concepts in Big Data Analytics", "id": 1 },
+            { "code": "AIT304", "date": "April 30, 2025 9:30:00", "name": "Robotics and Intelligent System", "id": 2 },
+            { "code": "CST306", "date": "May 7, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
+            { "code": "ADT---", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "ADT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
         ],
+
+        "AM": [
+            { "code": "AMT302", "date": "April 25, 2025 9:30:00", "name": "Concepts in Natural Language Processing", "id": 1 },
+            { "code": "AIT304", "date": "April 30, 2025 9:30:00", "name": "Robotics and Intelligent System", "id": 2 },
+            { "code": "CST306", "date": "May 7, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
+            { "code": "AMT---", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "AMT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+        ],
+
+        "BM": [
+            { "code": "BMT302", "date": "April 25, 2025 9:30:00", "name": "Biomechanics", "id": 1 },
+            { "code": "BMT304", "date": "April 30, 2025 9:30:00", "name": "Therapeutics Equipments", "id": 2 },
+            { "code": "BMT306", "date": "May 7, 2025 9:30:00", "name": "Principles of Medical Imaging", "id": 3 },
+            { "code": "BMT3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 6 },
+            { "code": "BMT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
+        ],
+
+        "BT": [
+            { "code": "BTT302", "date": "April 25, 2025 9:30:00", "name": "Bioinformatics", "id": 1 },
+            { "code": "BTT304", "date": "April 30, 2025 9:30:00", "name": "Downstream Processing", "id": 2 },
+            { "code": "BTT306", "date": "May 7, 2025 9:30:00", "name": "Bioreactor Control and Instrumentation", "id": 3 },
+            { "code": "BTT3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 6 },
+            { "code": "BTT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
+        ],
+
+        "CA": [
+            { "code": "CST302", "date": "April 25, 2025 9:30:00", "name": "Compiler Design", "id": 1 },
+            { "code": "AIT304", "date": "April 30, 2025 9:30:00", "name": "Robotics and Intelligent System", "id": 2 },
+            { "code": "CST306", "date": "May 7, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
+            { "code": "CAT---", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 6 },
+            { "code": "CAT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
+        ],
+
+        "CC": [
+            { "code": "CST302", "date": "April 25, 2025 9:30:00", "name": "Compiler Design", "id": 1 },
+            { "code": "CCT304", "date": "April 30, 2025 9:30:00", "name": "Cyber Forensics", "id": 2 },
+            { "code": "CST306", "date": "May 7, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
+            { "code": "CST---", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "CCT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+        ],
+
+        "CS": [
+            { "code": "CST302", "date": "April 25, 2025 9:30:00", "name": "Compiler Design", "id": 1 },
+            { "code": "CST304", "date": "April 30, 2025 9:30:00", "name": "Computer Graphics And Image Processing", "id": 2 },
+            { "code": "CST306", "date": "May 7, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 3 },
+            { "code": "CST3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 5 },
+            { "code": "CST308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+        ],
+
         "IT": [
-            { "code": "ITT302", "date": "May 23, 2024 9:30:00", "name": "Internetworking With TCP/IP", "id": 1 },
-            { "code": "ITT304", "date": "May 28, 2024 9:30:00", "name": "Algorithm Analysis And Design", "id": 2 },
-            { "code": "ITT306", "date": "June 1, 2024 9:30:00", "name": "Data Science", "id": 3 },
-            { "code": "ITT3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "ITT308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+            { "code": "ITT302", "date": "April 25, 2025 9:30:00", "name": "Internetworking With TCP/IP", "id": 1 },
+            { "code": "ITT304", "date": "April 30, 2025 9:30:00", "name": "Algorithm Analysis And Design", "id": 2 },
+            { "code": "ITT306", "date": "May 7, 2025 9:30:00", "name": "Data Science", "id": 3 },
+            { "code": "ITT3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management For Engineers", "id": 5 },
+            { "code": "ITT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
         ],
 
         "EC": [
-            { "code": "ECT302", "date": "May 23, 2024 9:30:00", "name": "Electromagnetics", "id": 1 },
-            { "code": "ECT304", "date": "May 28, 2024 9:30:00", "name": "VlSI Circuit Design", "id": 2 },
-            { "code": "ECT306", "date": "June 1, 2024 9:30:00", "name": "Information Theory And Coding", "id": 3 },
-            { "code": "ECT3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "HUT310", "date": "June 11, 2024 9:30:00", "name": "Management For Engineers", "id": 5 },
-            { "code": "ECT308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+            { "code": "ECT302", "date": "April 25, 2025 9:30:00", "name": "Electromagnetics", "id": 1 },
+            { "code": "ECT304", "date": "April 30, 2025 9:30:00", "name": "VLSI Circuit Design", "id": 2 },
+            { "code": "ECT306", "date": "May 7, 2025 9:30:00", "name": "Information Theory And Coding", "id": 3 },
+            { "code": "ECT3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management For Engineers", "id": 6 },
+            { "code": "ECT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
         ],
+
+        "ER": [
+            { "code": "ERT302", "date": "April 25, 2025 9:30:00", "name": "Operating Systems ", "id": 1 },
+            { "code": "ERT304", "date": "April 30, 2025 9:30:00", "name": "Embedded Systems & IoT", "id": 2 },
+            { "code": "ERT306", "date": "May 7, 2025 9:30:00", "name": "Data Communication and Networking", "id": 3 },
+            { "code": "ERT–", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "ERT308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+        ],
+
         "ME": [
-            { "code": "MET302", "date": "May 23, 2024 9:30:00", "name": "Heat & Mass Transfer", "id": 1 },
-            { "code": "MET304", "date": "May 28, 2024 9:30:00", "name": "Dynamics Of Machinery & Machine Design", "id": 2 },
-            { "code": "MET306", "date": "June 1, 2024 9:30:00", "name": "Advanced Manufacturing Engineering", "id": 3 },
-            { "code": "MET3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "MET310", "date": "June 11, 2024 9:30:00", "name": "Management For Engineers", "id": 5 },
-            { "code": "MET308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
+            { "code": "MET302", "date": "April 25, 2025 9:30:00", "name": "Heat & Mass Transfer", "id": 1 },
+            { "code": "MET304", "date": "April 30, 2025 9:30:00", "name": "Dynamics Of Machinery & Machine Design", "id": 2 },
+            { "code": "MET306", "date": "May 7, 2025 9:30:00", "name": "Advanced Manufacturing Engineering", "id": 3 },
+            { "code": "MET3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 6 },
+            { "code": "MET308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 },
         ],
     
         "EE": [
-            { "code": "EET302", "date": "May 23, 2024 9:30:00", "name": "Linear Control Systems", "id": 1 },
-            { "code": "EET304", "date": "May 28, 2024 9:30:00", "name": "Power Systems II", "id": 2 },
-            { "code": "EET306", "date": "June 1, 2024 9:30:00", "name": "Power Electronics", "id": 3 },
-            { "code": "EET3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "HUT310", "date": "June 11, 2024 9:30:00", "name": "Management For Engineers", "id": 5 },
-            { "code": "EET308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+            { "code": "EET302", "date": "April 25, 2025 9:30:00", "name": "Linear Control Systems", "id": 1 },
+            { "code": "EET304", "date": "April 30, 2025 9:30:00", "name": "Power Systems II", "id": 2 },
+            { "code": "EET306", "date": "May 7, 2025 9:30:00", "name": "Power Electronics", "id": 3 },
+            { "code": "EET3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management For Engineers", "id": 6 },
+            { "code": "EET308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
         ],
 
         "CE": [
-            { "code": "CET302", "date": "May 23, 2024 9:30:00", "name": "Structural Analysis – II", "id": 1 },
-            { "code": "CET304", "date": "May 28, 2024 9:30:00", "name": "Environmental Engineering", "id": 2 },
-            { "code": "CET306", "date": "June 1, 2024 9:30:00", "name": "Design Of Hydraulic Structures", "id": 3 },
-            { "code": "CET3x2", "date": "June 6, 2024 9:30:00", "name": "Elective - I", "id": 4 },
-            { "code": "HUT300", "date": "June 11, 2024 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
-            { "code": "CET308", "date": "June 14, 2024 9:30:00", "name": "Comprehensive Course Work", "id": 6 }
+            { "code": "CET302", "date": "April 25, 2025 9:30:00", "name": "Structural Analysis - II", "id": 1 },
+            { "code": "CET304", "date": "April 30, 2025 9:30:00", "name": "Environmental Engineering", "id": 2 },
+            { "code": "CET306", "date": "May 7, 2025 9:30:00", "name": "Design of Hydraulic Structures", "id": 3 },
+            { "code": "CET3x2", "date": "May 12, 2025 9:30:00", "name": "Elective - I", "id": 4 },
+            { "code": "HUT300", "date": "May 15, 2025 9:30:00", "name": "Industrial Economics And Foreign Trade", "id": 5 },
+            { "code": "HUT310", "date": "May 15, 2025 9:30:00", "name": "Management for Engineers", "id": 6 },
+            { "code": "CET308", "date": "May 19, 2025 9:30:00", "name": "Comprehensive Course Work", "id": 7 }
         ],
         
     },
     "S8": {
+        "AD": [
+            { "code": "ADT402", "date": "April 16, 2025 9:30:00", "name": "Business Analytics", "id": 1 },
+            {"code": "ADT---", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "ADT---", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "CST4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "AM": [
+            { "code": "AMT402", "date": "April 16, 2025 9:30:00", "name": "Concepts in Reinforcement Learning", "id": 1 },
+            {"code": "AMT---", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "AMT---", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "AMT---", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "BM": [
+            { "code": "BMT402", "date": "April 16, 2025 9:30:00", "name": "Biomaterials", "id": 1 },
+            {"code": "BMT4X4", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "BMT4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "BMT4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "BT": [
+            { "code": "BTT402", "date": "April 16, 2025 9:30:00", "name": "Environmental Biotechnology", "id": 1 },
+            {"code": "BTT4X4", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "BTT4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "BTT4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "CA": [
+            { "code": "AIT402", "date": "April 16, 2025 9:30:00", "name": "Robotic Process Automation", "id": 1 },
+            {"code": "CAT---", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "CAT---", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "CST4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "CE": [
+            { "code": "CET402", "date": "April 16, 2025 9:30:00", "name": "Quantity Surveying and Valuation", "id": 1 },
+            {"code": "CET4X4", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "CET4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "CET4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
+        "CC": [
+            { "code": "CCT402", "date": "April 16, 2025 9:30:00", "name": "Biometric Security", "id": 1 },
+            {"code": "CCT---", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "CCT---", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "CST4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
         "CS": [
-            { "code": "CST402", "date": "May 22, 2024 9:30:00", "name": "Distributed Computing", "id": 1 },
-            {"code": "CST4XX", "date": "May 27, 2024 9:30:00", "name": "Program Elective 3", "id":2},
-            {"code": "CST4XX", "date": "May 30, 2024 9:30:00", "name": "Program Elective 4", "id":3},
-            {"code": "CST4XX", "date": "June 3, 2024 9:30:00", "name": "Program Elective 5", "id":4},
+            { "code": "CST402", "date": "April 16, 2025 9:30:00", "name": "Distributed Computing", "id": 1 },
+            {"code": "CST4X4", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "CST4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "CST4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
         ],
+
         "EC":[
-            { "code": "ECT402", "date": "May 22, 2024 9:30:00", "name": "Wireless Communications", "id": 1 },
-            {"code": "ECT4XX", "date": "May 27, 2024 9:30:00", "name": "Program Elective 3", "id":2},
-            {"code": "ECT4XX", "date": "May 30, 2024 9:30:00", "name": "Program Elective 4", "id":3},
-            {"code": "ECT4XX", "date": "June 3, 2024 9:30:00", "name": "Program Elective 5", "id":4},
+            { "code": "ECT402", "date": "April 16, 2025 9:30:00", "name": "Wireless Communication", "id": 1 },
+            {"code": "ECT4X4", "date": "April 22, 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "ECT4XX", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "ECT4XX", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
         ],
+
         "EE":[
-            { "code": "EET402", "date": "May 22, 2024 9:30:00", "name": "Electrical System Design and Estimation", "id": 1 },
-            {"code": "EET4XX", "date": "May 27, 2024 9:30:00", "name": "Program Elective 3", "id":2},
-            {"code": "EET4XX", "date": "May 30, 2024 9:30:00", "name": "Program Elective 4", "id":3},
-            {"code": "EET4XX", "date": "June 3, 2024 9:30:00", "name": "Program Elective 5", "id":4},
+            { "code": "EET402", "date": "April 16, 2025 9:30:00", "name": "Electrical System Design and Estimation", "id": 1 },
+            {"code": "EET4X4", "date": "April 22, 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "EET4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "EET4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
         ],
+
+        "ER": [
+            { "code": "ERT402", "date": "April 16, 2025 9:30:00", "name": "Algorithm Analysis and Design", "id": 1 },
+            {"code": "ERT4X4", "date": "April 22 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "XXX", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "XXX", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
+        ],
+
         "IT":[
-            { "code": "ITT402", "date": "May 22, 2024 9:30:00", "name": "Cryptography and Network Security", "id": 1 },
-            {"code": "ITT4XX", "date": "May 27, 2024 9:30:00", "name": "Program Elective 3", "id":2},
-            {"code": "ITT4XX", "date": "May 30, 2024 9:30:00", "name": "Program Elective 4", "id":3},
-            {"code": "ITT4XX", "date": "June 3, 2024 9:30:00", "name": "Program Elective 5", "id":4},
+            { "code": "ITT402", "date": "April 16, 2025 9:30:00", "name": "Cryptography and Network Security", "id": 1 },
+            {"code": "ITT4X4", "date": "April 22, 2025 9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "ITT4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "ITT4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
         ],
         "ME":[
-            { "code": "MET402", "date": "May 22, 2024 9:30:00", "name": "Mechatronics", "id": 1 },
-            {"code": "MET4XX", "date": "May 27, 2024 9:30:00", "name": "Program Elective 3", "id":2},
-            {"code": "MET4XX", "date": "May 30, 2024 9:30:00", "name": "Program Elective 4", "id":3},
-            {"code": "MET4XX", "date": "June 3, 2024 9:30:00", "name": "Program Elective 5", "id":4},
+            { "code": "MET402", "date": "April 16, 2025 9:30:00", "name": "Mechatronics", "id": 1 },
+            {"code": "MET4X4", "date": "April 22, 2025   9:30:00", "name": "Program Elective 3", "id":2},
+            {"code": "MET4X6", "date": "April 24, 2025 9:30:00", "name": "Program Elective 4", "id":3},
+            {"code": "MET4X8", "date": "April 29, 2025 9:30:00", "name": "Program Elective 5", "id":4},
         ],
     }
 


### PR DESCRIPTION
Timetable update with pdf schedule.

[DetailedTimeTableofB.TechS4(R,S)incl.WorkingProfessionals.pdf](https://github.com/user-attachments/files/19620607/DetailedTimeTableofB.TechS4.R.S.incl.WorkingProfessionals.pdf)

[DetailedTimeTableofB.TechS6(R,S)Examination(2019scheme)incl..pdf](https://github.com/user-attachments/files/19620608/DetailedTimeTableofB.TechS6.R.S.Examination.2019scheme.incl.pdf)

[RevisedDetailedTimeTable-B.TechS8(R,S)ExamApril2025publish.pdf](https://github.com/user-attachments/files/19620606/RevisedDetailedTimeTable-B.TechS8.R.S.ExamApril2025publish.pdf)

Fixes #9 